### PR TITLE
Chore: 스터디 룸 참가 및 나가기 로직 수정 

### DIFF
--- a/src/apis/study-room/join-study-room.ts
+++ b/src/apis/study-room/join-study-room.ts
@@ -5,7 +5,7 @@ interface JoinStudyRoomParams {
 }
 
 interface JoinStudyRoomResponse {
-  userId: number;
+  participantId: number;
 }
 
 export const joinStudyRoom = async ({
@@ -13,5 +13,5 @@ export const joinStudyRoom = async ({
 }: JoinStudyRoomParams): Promise<JoinStudyRoomResponse> => {
   const { data } = await http.post(`/studyrooms/${studyRoomId}/participants`);
 
-  return { userId: data.id };
+  return { participantId: data.id };
 };

--- a/src/apis/study-room/join-study-room.ts
+++ b/src/apis/study-room/join-study-room.ts
@@ -5,7 +5,7 @@ interface JoinStudyRoomParams {
 }
 
 interface JoinStudyRoomResponse {
-  participantId: number;
+  id: number;
 }
 
 export const joinStudyRoom = async ({
@@ -13,5 +13,5 @@ export const joinStudyRoom = async ({
 }: JoinStudyRoomParams): Promise<JoinStudyRoomResponse> => {
   const { data } = await http.post(`/studyrooms/${studyRoomId}/participants`);
 
-  return { participantId: data.id };
+  return data;
 };

--- a/src/pages/study-room/hooks/useExitStudyRoom.ts
+++ b/src/pages/study-room/hooks/useExitStudyRoom.ts
@@ -11,15 +11,19 @@ interface UseExitStudyRoom {
 
 const useExitStudyRoom = ({ studyId, close }: UseExitStudyRoom) => {
   const navigate = useNavigate();
-  const { state: blockState, proceed } = useBlocker(
-    ({ currentLocation, nextLocation }) => currentLocation.pathname !== nextLocation.pathname,
-  );
+  useBlocker(({ currentLocation, nextLocation, historyAction }) => {
+    if (historyAction === 'POP') {
+      return currentLocation.pathname !== nextLocation.pathname;
+    }
+    return currentLocation.pathname === nextLocation.pathname;
+  });
 
-  const { mutate: exitStudyRoomMutate } = useExitStudyRoomMutation({ proceed, close, navigate });
+  const { mutate: exitStudyRoomMutate } = useExitStudyRoomMutation({
+    close,
+    navigate,
+  });
 
   const exitStudyRoom = () => {
-    if (blockState !== 'blocked') return;
-
     const participantId = getLocalStorage('participantId');
     exitStudyRoomMutate({ studyRoomId: studyId, participantId: Number(participantId) });
   };

--- a/src/pages/study-room/hooks/useExitStudyRoom.ts
+++ b/src/pages/study-room/hooks/useExitStudyRoom.ts
@@ -1,8 +1,9 @@
 import { useBlocker, useNavigate } from 'react-router-dom';
 
-import { getLocalStorage } from '@/utils/storage';
+import { getLocalStorage, removeLocalStorage } from '@/utils/storage';
 
 import useExitStudyRoomMutation from './useExitStudyRoomMutation';
+import { ROUTE_PATH } from '@/constant/routes';
 
 interface UseExitStudyRoom {
   studyId: number;
@@ -11,6 +12,7 @@ interface UseExitStudyRoom {
 
 const useExitStudyRoom = ({ studyId, close }: UseExitStudyRoom) => {
   const navigate = useNavigate();
+
   useBlocker(({ currentLocation, nextLocation, historyAction }) => {
     if (historyAction === 'POP') {
       return currentLocation.pathname !== nextLocation.pathname;
@@ -18,10 +20,13 @@ const useExitStudyRoom = ({ studyId, close }: UseExitStudyRoom) => {
     return currentLocation.pathname === nextLocation.pathname;
   });
 
-  const { mutate: exitStudyRoomMutate } = useExitStudyRoomMutation({
-    close,
-    navigate,
-  });
+  const exitStudyRoomAction = () => {
+    close();
+    removeLocalStorage('participantId');
+    navigate(ROUTE_PATH.STUDY_ROOMS);
+  };
+
+  const { mutate: exitStudyRoomMutate } = useExitStudyRoomMutation({ exitStudyRoomAction });
 
   const exitStudyRoom = () => {
     const participantId = getLocalStorage('participantId');

--- a/src/pages/study-room/hooks/useExitStudyRoomMutation.ts
+++ b/src/pages/study-room/hooks/useExitStudyRoomMutation.ts
@@ -1,20 +1,20 @@
 import { exitStudyRoom } from '@/apis/study-room/exit-study-room';
 import { ROUTE_PATH } from '@/constant/routes';
+import { removeLocalStorage } from '@/utils/storage';
 import { useMutation } from '@tanstack/react-query';
 import { NavigateOptions, To } from 'react-router-dom';
 
 interface UseExitStudyRoomMutation {
-  proceed?: () => void;
   close: () => void;
   navigate: (to: To, options?: NavigateOptions) => void;
 }
 
-const useExitStudyRoomMutation = ({ proceed, close, navigate }: UseExitStudyRoomMutation) => {
+const useExitStudyRoomMutation = ({ close, navigate }: UseExitStudyRoomMutation) => {
   return useMutation({
     mutationFn: exitStudyRoom,
     onSuccess: () => {
-      proceed?.();
       close();
+      removeLocalStorage('participantId');
       navigate(ROUTE_PATH.STUDY_ROOMS);
     },
   });

--- a/src/pages/study-room/hooks/useExitStudyRoomMutation.ts
+++ b/src/pages/study-room/hooks/useExitStudyRoomMutation.ts
@@ -1,22 +1,14 @@
 import { exitStudyRoom } from '@/apis/study-room/exit-study-room';
-import { ROUTE_PATH } from '@/constant/routes';
-import { removeLocalStorage } from '@/utils/storage';
 import { useMutation } from '@tanstack/react-query';
-import { NavigateOptions, To } from 'react-router-dom';
 
 interface UseExitStudyRoomMutation {
-  close: () => void;
-  navigate: (to: To, options?: NavigateOptions) => void;
+  exitStudyRoomAction: () => void;
 }
 
-const useExitStudyRoomMutation = ({ close, navigate }: UseExitStudyRoomMutation) => {
+const useExitStudyRoomMutation = ({ exitStudyRoomAction }: UseExitStudyRoomMutation) => {
   return useMutation({
     mutationFn: exitStudyRoom,
-    onSuccess: () => {
-      close();
-      removeLocalStorage('participantId');
-      navigate(ROUTE_PATH.STUDY_ROOMS);
-    },
+    onSuccess: exitStudyRoomAction,
   });
 };
 

--- a/src/pages/study-room/provider/exit-room-modal-provider.tsx
+++ b/src/pages/study-room/provider/exit-room-modal-provider.tsx
@@ -20,6 +20,7 @@ const ExitRoomModalProvdier = ({ children }: PropsWithChildren) => {
   const [isOpen, open, close] = useBooleanState();
 
   const { id: studyId } = useParams() as { id: string };
+
   const { exitStudyRoom } = useExitStudyRoom({ studyId: Number(studyId), close });
 
   const clickExit = () => exitStudyRoom();
@@ -30,7 +31,7 @@ const ExitRoomModalProvdier = ({ children }: PropsWithChildren) => {
       {isOpen && (
         <Modal
           isOpen={isOpen}
-          title="스터디룸 생성"
+          title="스터디룸 나가기"
           closeBtn="취소"
           actionBtn="나가기"
           onClickActionBtn={clickExit}

--- a/src/pages/study-rooms/components/study-room-list.tsx
+++ b/src/pages/study-rooms/components/study-room-list.tsx
@@ -19,8 +19,8 @@ const StudyRoomList = () => {
 
   const handleJoinStudyRoom = async (studyRoomId: number) => {
     try {
-      const { participantId } = await joinStudyRoom({ studyRoomId });
-
+      const data = await joinStudyRoom({ studyRoomId });
+      const { id: participantId } = data;
       setLocalStorage({ key: 'participantId', value: String(participantId) });
       navigate(`${ROUTE_PATH.STUDY_ROOMS}/${studyRoomId}`);
     } catch (e) {

--- a/src/pages/study-rooms/components/study-room-list.tsx
+++ b/src/pages/study-rooms/components/study-room-list.tsx
@@ -4,6 +4,7 @@ import { ROUTE_PATH } from '@/constant/routes';
 import { joinStudyRoom } from '@/apis/study-room/join-study-room';
 import useStudyRoomsQuery from '@/pages/study-rooms/hooks/useStudyRoomsQuery';
 import StudyRoomListItem from './study-room-list-item';
+import { setLocalStorage } from '@/utils/storage';
 
 const StudyRoomList = () => {
   const navigate = useNavigate();
@@ -18,8 +19,9 @@ const StudyRoomList = () => {
 
   const handleJoinStudyRoom = async (studyRoomId: number) => {
     try {
-      await joinStudyRoom({ studyRoomId });
+      const { participantId } = await joinStudyRoom({ studyRoomId });
 
+      setLocalStorage({ key: 'participantId', value: String(participantId) });
       navigate(`${ROUTE_PATH.STUDY_ROOMS}/${studyRoomId}`);
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
### 스터디룸 참가 
- 스터디룸 참가 시 참가자 id key 수정
- 스터디룸 참가 시 참가자 ID 값 localStorage에 저장

### 스터디룸 나가기 
- 뒤로가기 여부 확인을 위해 historyAction 파라미터 추가
-  historyAction 값에 따라 뒤로가기 기능 block 여부 로직 추가
- 스터디룸 나가기 시 localStorage에 저장되어있는 참가자 ID 값 삭제
- 사용하지 않는 proceed 함수 삭제
- 스터디룸 나가기 모달 창 스터디룸 생성-> 스터디룸 나가기로 수정
