### PR TITLE
Feat: 참가자 목록에 사용자가 없을 경우 스터디룸 목록으로 강제 이동 로직 추가

### DIFF
--- a/src/pages/study-room/hooks/useStudyRoomQuery.ts
+++ b/src/pages/study-room/hooks/useStudyRoomQuery.ts
@@ -1,31 +1,15 @@
-import { useQuery } from '@tanstack/react-query';
-import { StudyRoomInfo } from '@/types/study-room.types';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { getStudyRoomInfo } from '@/apis/study-room/get-study-room-info';
 
 interface UseStudyRoomQuery {
   studyId: number;
 }
 
-const initialStudyRoom: StudyRoomInfo = {
-  id: 0,
-  name: '',
-  intro: '',
-  step: 'PLANNING',
-  timeSet: {
-    planningTime: 0,
-    studyingTime: 0,
-    retrospectTime: 0,
-    restingTime: 0,
-  },
-  participantSummaries: [],
-  updateAt: '',
-};
-
 const useStudyRoomQuery = ({ studyId }: UseStudyRoomQuery) => {
-  return useQuery({
-    queryKey: ['get-study-room-info'],
+  return useSuspenseQuery({
+    queryKey: ['get-study-room-info', studyId],
     queryFn: () => getStudyRoomInfo({ studyId }),
-    initialData: initialStudyRoom,
+    gcTime: 0,
   });
 };
 

--- a/src/pages/study-room/study-room.tsx
+++ b/src/pages/study-room/study-room.tsx
@@ -6,15 +6,20 @@ import Timer from './components/timer';
 import { Box, Container, Grid } from '@mui/material';
 
 import { useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { ROUTE_PATH } from '@/constant/routes';
+import { participantIdStorage } from '@/utils/storage';
 
 import useSockJSContext from './hooks/useSockJSContext';
 import useStudyRoomQuery from './hooks/useStudyRoomQuery';
 import useExitRoomModalContext from './hooks/useExitRoomModalContext';
-  
+
 import getProgressTime from '@/pages/study-room/utils/get-progress-time';
 
 const StudyRoom = () => {
+  const navigate = useNavigate();
+
   const { id: studyId } = useParams();
 
   const { open } = useExitRoomModalContext();
@@ -36,6 +41,8 @@ const StudyRoom = () => {
     updateAt,
   };
 
+  const participantId = participantIdStorage.getItem();
+
   useEffect(() => {
     window.addEventListener('popstate', open);
 
@@ -44,6 +51,18 @@ const StudyRoom = () => {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    const hasOwnId = participantSummaries?.some((participant) => participant.id === participantId);
+
+    if (participantSummaries && !hasOwnId) {
+      // TODO : 스터디룸 접속 시간이 길어져 자동으로 퇴장됐다는 알림 메세지 띄우기
+
+      participantIdStorage.clear();
+
+      !hasOwnId && navigate(ROUTE_PATH.STUDY_ROOMS);
+    }
+  }, [participantSummaries, participantId, navigate]);
 
   if (isLoading) {
     return <Spinner />;


### PR DESCRIPTION
- 새로고침으로 인한 소켓 연결 해제 이슈에 대한 서버 로직 조치(연결 해제 이후 10초 내에 재연결하지 않을 경우 강퇴 조치) 후 프론트엔드 로직 변경
  - 새로고침으로 인한 스터디룸 재입장 시, 로딩이 10초 이상 걸릴 경우 시간초과로 참가자 목록에서 제외되어 스터디룸 목록으로 강제 이동 
  - 비정상적으로 잦은 새로고침 시 소켓 연결이 정상적으로 이루어지지 않아 참여자 목록에서 제거되어 스터디룸 목록으로 강제 이동
  - 새로고침 시, 실시간 참가자 목록 파악을 위해 스터디룸 조회 쿼리 캐싱 제거